### PR TITLE
Change EventEmitter to Subject

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,23 +5,21 @@
 import { NgModule, ModuleWithProviders } from "@angular/core";
 
 import { SlimLoadingBarComponent } from './src/slim-loading-bar.component';
-import { SlimLoadingBarService, slimLoadingBarServiceFactory } from './src/slim-loading-bar.service';
+import { SlimLoadingBarService } from './src/slim-loading-bar.service';
 
 export * from './src/slim-loading-bar.component';
 export * from './src/slim-loading-bar.service';
 
-export let providers = [{ provide: SlimLoadingBarService, useFactory: slimLoadingBarServiceFactory }];
-
 @NgModule({
     declarations: [SlimLoadingBarComponent],
     exports: [SlimLoadingBarComponent],
-    providers: providers
+    providers: [SlimLoadingBarService]
 })
 export class SlimLoadingBarModule {
     static forRoot(): ModuleWithProviders {
         return {
             ngModule: SlimLoadingBarModule,
-            providers: providers
+            providers: [SlimLoadingBarService]
         };
     }
 }

--- a/src/slim-loading-bar.service.ts
+++ b/src/slim-loading-bar.service.ts
@@ -2,9 +2,11 @@
 // This project is licensed under the terms of the MIT license.
 // https://github.com/akserg/ng2-slim-loading-bar
 
-import {Injectable, EventEmitter} from '@angular/core';
+import {Injectable} from '@angular/core';
 
 import {isPresent} from './slim-loading-bar.utils';
+import {Subject} from 'rxjs/Subject';
+import {Observable} from 'rxjs/Observable';
 
 export enum SlimLoadingBarEventType {
     PROGRESS,
@@ -16,10 +18,6 @@ export enum SlimLoadingBarEventType {
 export class SlimLoadingBarEvent {
     constructor(public type:SlimLoadingBarEventType, public value:any) {}
 }
-
-export function slimLoadingBarServiceFactory(): SlimLoadingBarService  {
-    return new SlimLoadingBarService(new EventEmitter<SlimLoadingBarEvent>());
- }
 
 /**
  * SlimLoadingBar service helps manage Slim Loading bar on the top of screen or parent component
@@ -35,7 +33,10 @@ export class SlimLoadingBarService {
     private _intervalCounterId:any = 0;
     public interval:number = 500; // in milliseconds
 
-    constructor(public events: EventEmitter<SlimLoadingBarEvent>) {}
+    private eventSource: Subject<SlimLoadingBarEvent> = new Subject<SlimLoadingBarEvent>();
+    public events: Observable<SlimLoadingBarEvent> = this.eventSource.asObservable();
+
+    constructor() {}
 
     set progress(value:number) {
         if (isPresent(value)) {
@@ -86,9 +87,9 @@ export class SlimLoadingBarService {
     }
 
     private emitEvent(event: SlimLoadingBarEvent) {
-        if (this.events) {
+        if (this.eventSource) {
             // Push up a new event
-            this.events.next(event);
+            this.eventSource.next(event);
         }
     }
 

--- a/tests/slim-loading-bar.component.spec.ts
+++ b/tests/slim-loading-bar.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, ComponentFixture }
     from '@angular/core/testing';
 
-import {SlimLoadingBarService, slimLoadingBarServiceFactory} 
+import {SlimLoadingBarService} 
     from '../src/slim-loading-bar.service';
 import {SlimLoadingBarComponent} 
     from '../src/slim-loading-bar.component';
@@ -12,7 +12,7 @@ describe('SlimLoadingBar', () => {
     let containerDiv:HTMLDivElement;
     let progressDiv:HTMLDivElement;
 
-    let providers = [{ provide: SlimLoadingBarService, useFactory: slimLoadingBarServiceFactory }];
+    let providers = [SlimLoadingBarService];
 
     beforeEach(() => {
         TestBed.configureTestingModule({

--- a/tests/slim-loading-bar.service.spec.ts
+++ b/tests/slim-loading-bar.service.spec.ts
@@ -1,13 +1,13 @@
 import { inject, fakeAsync, tick, TestBed }
     from '@angular/core/testing';
 
-import {SlimLoadingBarService, slimLoadingBarServiceFactory}
+import {SlimLoadingBarService}
     from '../src/slim-loading-bar.service';
 
 describe('SlimLoadingBarService', () => {
 
     let service: SlimLoadingBarService;
-    let providers = [{ provide: SlimLoadingBarService, useFactory: slimLoadingBarServiceFactory }];
+    let providers = [SlimLoadingBarService];
 
     beforeEach(() => {
         TestBed.configureTestingModule({


### PR DESCRIPTION
Removes the need for the service factory

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix for #32 . 
Update to 2.0.5 introduced `slimLoadingBarServiceFactory`, which wasn't documented in README and caused errors in tests. In the commit message, there was written that it should fix AOT issue, but i'm not sure what the issue was in the first place.
This fix uses `Subject` instead of `EventEmitter` and it doesn't need to be provided in the constructor of the service (which was the main issue there). 
I tried running ngc and it worked, so i assume there is no issue with AOT now.

This method with `Subject` is documented also in the official Angular docs: https://angular.io/docs/ts/latest/cookbook/component-communication.html#!#bidirectional-service

Something on the topic `EventEmitter` vs `Subject`: http://stackoverflow.com/questions/40238549/angular-2-event-emitters-vs-subject
