### PR TITLE
Invoke callback passed to `start` method

### DIFF
--- a/src/slim-loading-bar.service.ts
+++ b/src/slim-loading-bar.service.ts
@@ -105,7 +105,7 @@ export class SlimLoadingBarService {
             this.progress++;
             // If the progress is 100% - call complete
             if (this.progress === 100) {
-                this.complete();
+                this.complete(onCompleted);
             }
         }, this.interval);
     }
@@ -122,7 +122,7 @@ export class SlimLoadingBarService {
         this.progress = 0;
     }
 
-    complete() {
+    complete(onCompleted: Function = null) {
         this.progress = 100;
         this.stop();
         setTimeout(() => {
@@ -131,6 +131,9 @@ export class SlimLoadingBarService {
             setTimeout(() => {
                 // Drop to 0
                 this.progress = 0;
+                if (onCompleted) {
+                    onCompleted();
+                }
             }, 250);
         }, 250);
     }


### PR DESCRIPTION
You accept an `onCompleted` callback in the `start` method, but you never actually invoke it.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

None


* **What is the new behavior (if this is a feature change)?**

Invoke callback

* **Other information**:
