### PR TITLE
Progress bar stays loading forever (until completed is called) and an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ export class SharedModule {
 #### 3. Use the `SlimLoadingBarService` for your application
 - Import `SlimLoadingBarService` from `ng2-slim-loading-bar` in your application code:
 
-```js
+```typescript
 import {Component} from '@angular/core';
 import {SlimLoadingBarService} from 'ng2-slim-loading-bar';
 
@@ -98,9 +98,7 @@ export class AppComponent {
     constructor(private slimLoadingBarService: SlimLoadingBarService) { }
 
     startLoading() {
-        this.slimLoadingBarService.start(() => {
-            console.log('Loading complete');
-        });
+        this.slimLoadingBarService.start();
     }
 
     stopLoading() {
@@ -118,6 +116,7 @@ You can use the following properties to customize the `ng2-slim-loading-bar` com
 - `color` - The color of loading bar. Default is `firebrick`. It can be any CSS compatible value.
 - `height` - The height of loading bar. Default value is `2px`.
 - `show` - The flag helps hide and show the loading bar. Default value is `true`.
+- `transitionTimingFunction` - The transition timing function the bar will use when incrementing the progress in the bar. Default value is `'linear'`.
 
 Example: 
 `<ng2-slim-loading-bar color="blue" height="4px"></ng2-slim-loading-bar>`
@@ -127,6 +126,7 @@ You can use the following properties to customize the SlimLoadingBar via instanc
 - `color` - The color of loading bar.
 - `height` - The height of loading bar.
 - `visible` - The flag helps hide and show the loading bar, false for hidden and true for visible.
+- `growSpeed` - The speed of the progress bar when start is called. It can be any number grater than 0, but. It is 0.1 by default.
 
 You can use the following methods to control the SlimLoadingBar via instance of SlimLoadingBarService:
 - `start` - Start the loading progress. Use the callback function as an parameter to listed the complete event.
@@ -142,7 +142,7 @@ You can hook up with our different types of events thrown.
 - `SlimLoadingBarEventType.VISIBLE`
 
 you can subscribe to these events types by simplying doing this
-```js
+```typescript
  constructor(private _loadingBar: SlimLoadingBarService) {
     this._loadingBar.events.subscribe((item:SlimLoadingBarEvent) => console.log(item));
    }

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can hook up with our different types of events thrown.
 - `SlimLoadingBarEventType.COLOR`
 - `SlimLoadingBarEventType.VISIBLE`
 
-you can subscribe to these events types by simplying doing this
+you can subscribe to these events types simply by doing this
 ```typescript
  constructor(private _loadingBar: SlimLoadingBarService) {
     this._loadingBar.events.subscribe((item:SlimLoadingBarEvent) => console.log(item));

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/core": "^2.4.7 || ^4.3.0"
   },
   "devDependencies": {
-    "@angular/common": "^2.4.7 || ^4.3.0",
+    "@angular/common": "^2.4.7",
     "@angular/compiler": "^2.4.7",
     "@angular/compiler-cli": "^2.4.7",
     "@angular/core": "^2.4.7",

--- a/src/slim-loading-bar.component.ts
+++ b/src/slim-loading-bar.component.ts
@@ -4,7 +4,7 @@
 
 import { Component, Input, OnInit, AfterViewInit, ChangeDetectorRef, ChangeDetectionStrategy, ElementRef } from '@angular/core';
 
-import { SlimLoadingBarService, SlimLoadingBarEvent, SlimLoadingBarEventType } from './slim-loading-bar.service';
+import { SlimLoadingBarService, SlimLoadingBarEvent, SlimLoadingBarEventType, TransitionTimingFunction } from './slim-loading-bar.service';
 import { isPresent } from './slim-loading-bar.utils';
 
 /**
@@ -25,7 +25,7 @@ export class SlimLoadingBarComponent implements OnInit, AfterViewInit {
 
     private _progress: string = '0';
     @Input() set progress(progress: string) {
-        this.isTransition = progress >= this._progress ?  'all 0.5s ease-in-out' : 'none';
+        this.isTransition = progress >= this._progress ?  `all ${this.service.interval}ms ${this.transitionTimingFunction}` : 'none';
         this._progress = progress;
     }
 
@@ -36,6 +36,7 @@ export class SlimLoadingBarComponent implements OnInit, AfterViewInit {
     @Input() color: string = 'firebrick';
     @Input() height: string = '2px';
     @Input() show: boolean = true;
+    @Input() transitionTimingFunction: TransitionTimingFunction = 'linear';
 
     constructor(public service: SlimLoadingBarService, private _elmRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef) { }
 
@@ -49,6 +50,8 @@ export class SlimLoadingBarComponent implements OnInit, AfterViewInit {
                 this.height = event.value;
             } else if (event.type === SlimLoadingBarEventType.VISIBLE) {
                 this.show = event.value;
+            } else if (event.type === SlimLoadingBarEventType.TRANSITION_TIMING_FUNCTION) {
+                this.transitionTimingFunction = event.value;
             }
         });
     }
@@ -58,5 +61,5 @@ export class SlimLoadingBarComponent implements OnInit, AfterViewInit {
            this._elmRef.nativeElement.visible = event.type === SlimLoadingBarEventType.VISIBLE ? event.value : true;
            this._changeDetectorRef.detectChanges();
        });
-    }   
+    }
 }

--- a/tests/slim-loading-bar.component.spec.ts
+++ b/tests/slim-loading-bar.component.spec.ts
@@ -1,9 +1,9 @@
 import { TestBed, ComponentFixture }
     from '@angular/core/testing';
 
-import {SlimLoadingBarService} 
+import {SlimLoadingBarService}
     from '../src/slim-loading-bar.service';
-import {SlimLoadingBarComponent} 
+import {SlimLoadingBarComponent}
     from '../src/slim-loading-bar.component';
 
 describe('SlimLoadingBar', () => {
@@ -77,5 +77,12 @@ describe('SlimLoadingBar', () => {
         component.show = true;
         componentFixture.detectChanges();
         expect(progressDiv.style.opacity).toBe('1');
+    });
+
+    it ('should change the transition timing function when calling set transitionTimingFunction', () => {
+        component.progress = '30';
+        component.transitionTimingFunction = 'ease-in-out';
+        componentFixture.detectChanges();
+        expect(progressDiv.style.transition).toContain('ease-in-out');
     });
 });

--- a/tests/slim-loading-bar.service.spec.ts
+++ b/tests/slim-loading-bar.service.spec.ts
@@ -33,13 +33,59 @@ describe('SlimLoadingBarService', () => {
         expect(service.progress).toBe(30);
     });
 
-    it('increaments over time after calling start()', <any>fakeAsync((): void => {
+    it('increments over time after calling start()', <any>fakeAsync((): void => {
         // var value, flag;
         expect(service.progress).toBe(0);
         service.start();
 
         tick(500);
-        expect(service.progress).toBe(1);
+        expect(service.progress).toBeGreaterThan(0);
+        service.stop();
+    }));
+
+    it('is not completed never after calling start() if no other action is taken', <any>fakeAsync((): void => {
+        // var value, flag;
+        expect(service.progress).toBe(0);
+        service.start();
+
+        tick(10 * 60 * 1000); // 10 minutes
+        expect(service.progress).toBeLessThan(100);
+        service.stop();
+    }));
+
+    it('grows in an infinite sum fashion (0.5, 0.75, 0.875, ...) after calling start().', <any>fakeAsync((): void => {
+        // var value, flag;
+        expect(service.progress).toBe(0);
+        service.growSpeed = 1 / 10;
+        service.start();
+
+        tick(500);
+        expect(service.progress).toBeCloseTo(100 * (1 / 11), 1 / 1000);
+
+        tick(500);
+        expect(service.progress).toBeCloseTo(100 * (21 / 121), 1 / 1000);
+
+        tick(38 * 500);
+        expect(service.progress).toBeCloseTo(97.7905, 1 / 1000);
+
+        service.stop();
+    }));
+
+    it('grow rate after calling calling start() is based in growSpeed.', <any>fakeAsync((): void => {
+        // var value, flag;
+        expect(service.progress).toBe(0);
+        service.growSpeed = 1;
+        service.start();
+
+        tick(500);
+        expect(service.progress).toBeCloseTo(100 * (1 / 2), 1 / 1000);
+
+        tick(500);
+        expect(service.progress).toBeCloseTo(100 * (3 / 4), 1 / 1000);
+
+        tick(8 * 500);
+        expect(service.progress).toBeCloseTo(100 * (1023 / 1024), 1 / 1000);
+
         service.stop();
     }));
 
@@ -76,6 +122,14 @@ describe('SlimLoadingBarService', () => {
     it('set the color', () => {
         service.color = 'green';
         expect(service.color).toBe('green');
+    });
+
+    it('return current transition timing function ', () => {
+        expect(service.transitionTimingFunction).toBe('linear');
+    });
+    it('set the transition timing function', () => {
+        service.transitionTimingFunction = 'ease-in-out';
+        expect(service.transitionTimingFunction).toBe('ease-in-out');
     });
 
 });


### PR DESCRIPTION
…imation is much smother

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #61 
    * It makes the progress bar to grow in a way that allows it to not be completed ever (like in youtube) 
until the `complete` method is called, when `start` is called.
    * Made possible to change the transition timing function from the code.
    * Set the transition timing function to linear by default (looks better when the progress is changed by 
the start method)
    * Made the transition speed of the bar, equal to the velocity of the bar when start is called (That and 
the timing function being linear makes the loading way more smoother).
    * Removed the `completed` callback from the `start` method, because that callback will never be called under the new algorithm for the bar growth.

* **What is the current behavior?** (You can also link to an open issue here)
When `start` is called, the loading bar loads for 50 seconds until it looks completed.


* **What is the new behavior (if this is a feature change)?**
When `start` is called, the bar stays loading forever, showing increments of lower amounts as time progresses allowing for it to stay doing increments to the bar forever.
(9%, 17%, 25%, 32%, 38%, 44%, 49%, 53%, 58%, 61%, 65%, 68%, 71%, 74%, 76%, 78%, 80%, 82%, 84%, 85%, 86%, 88%, 89%, ...) but no 100%.

* **Other information**:

The velocity of this change can be modified by changing the field `growVelocity` in the service, and the higher the value, the more quickly the bar will look full.

