### PR TITLE
changed the reference to rxjs

### DIFF
--- a/src/slim-loading-bar.service.ts
+++ b/src/slim-loading-bar.service.ts
@@ -2,11 +2,10 @@
 // This project is licensed under the terms of the MIT license.
 // https://github.com/akserg/ng2-slim-loading-bar
 
-import {Injectable} from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import {isPresent} from './slim-loading-bar.utils';
-import {Subject} from 'rxjs/Subject';
-import {Observable} from 'rxjs/Observable';
+import { isPresent } from './slim-loading-bar.utils';
+import { Subject, Observable } from 'rxjs';
 
 export enum SlimLoadingBarEventType {
     PROGRESS,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixed the issue related when the version Angular & RxJs is updated to latest i.e. v6
`when installling on angular6 getting compilation error : 'Observable is not a member of rxjs/Observable' or 'Subject is not a member of rxjs/Observable '`

* **What is the current behavior?** (You can also link to an open issue here)
 #67 - where the library is still referring the RxJs module under wrong location when updated to RxJs v6

* **What is the new behavior (if this is a feature change)?**
No change in the functionality. Just updated the import change to point the new location

* **Other information**:
